### PR TITLE
feat: configurable decay half-life per memory type

### DIFF
--- a/pkg/membrane/config.go
+++ b/pkg/membrane/config.go
@@ -52,6 +52,18 @@ type Config struct {
 	// RateLimitPerSecond is the maximum requests per second per client.
 	// 0 means no rate limiting. Default: 100.
 	RateLimitPerSecond int `yaml:"rate_limit_per_second"`
+
+	// EpisodicHalfLifeSeconds overrides the decay half-life for episodic memories.
+	// Default: 3600 (1 hour). Recommended: 604800 (7 days) for persistent agents.
+	EpisodicHalfLifeSeconds int64 `yaml:"episodic_half_life_seconds"`
+
+	// SemanticHalfLifeSeconds overrides the decay half-life for semantic memories.
+	// Default: 2592000 (30 days).
+	SemanticHalfLifeSeconds int64 `yaml:"semantic_half_life_seconds"`
+
+	// WorkingHalfLifeSeconds overrides the decay half-life for working memories.
+	// Default: 86400 (1 day).
+	WorkingHalfLifeSeconds int64 `yaml:"working_half_life_seconds"`
 }
 
 // DefaultConfig returns a Config populated with sensible defaults.

--- a/pkg/membrane/membrane.go
+++ b/pkg/membrane/membrane.go
@@ -52,6 +52,15 @@ func New(cfg *Config) (*Membrane, error) {
 	classifier := ingestion.NewClassifier()
 	policyDefaults := ingestion.DefaultPolicyDefaults()
 	policyDefaults.Sensitivity = schema.Sensitivity(cfg.DefaultSensitivity)
+	if cfg.EpisodicHalfLifeSeconds > 0 {
+		policyDefaults.EpisodicHalfLifeSeconds = cfg.EpisodicHalfLifeSeconds
+	}
+	if cfg.SemanticHalfLifeSeconds > 0 {
+		policyDefaults.SemanticHalfLifeSeconds = cfg.SemanticHalfLifeSeconds
+	}
+	if cfg.WorkingHalfLifeSeconds > 0 {
+		policyDefaults.WorkingHalfLifeSeconds = cfg.WorkingHalfLifeSeconds
+	}
 	policyEngine := ingestion.NewPolicyEngine(policyDefaults)
 	ingestionSvc := ingestion.NewService(store, classifier, policyEngine)
 


### PR DESCRIPTION
## Problem

The default decay half-life for episodic memories is 3600 seconds (1 hour). For persistent AI agents that run 24/7, this means all episodic memories decay to zero overnight and get auto-pruned — effectively losing all conversation history every night.

The half-life values are currently hardcoded in `DefaultPolicyDefaults()` with no way to override them via config.

## Solution

Add three new config fields:
- `episodic_half_life_seconds` (default: 3600)
- `semantic_half_life_seconds` (default: 2592000) 
- `working_half_life_seconds` (default: 86400)

These are optional — if not set, the existing defaults apply. When set, they override the `PolicyDefaults` before the `PolicyEngine` is created.

## Example config

```yaml
# For persistent agents: 7-day episodic half-life
episodic_half_life_seconds: 604800
```

## Changes

- `pkg/membrane/config.go`: Add 3 config fields with YAML tags
- `pkg/membrane/membrane.go`: Pass config overrides to PolicyDefaults in `New()`

## Context

Discovered while debugging a production deployment where 29k+ backfilled records were pruned overnight due to the aggressive 1-hour default. The fix is minimal and backward-compatible.