### PR TITLE
Fix #31: Add --version support to membraned CLI

### DIFF
--- a/cmd/membraned/main.go
+++ b/cmd/membraned/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -12,11 +13,19 @@ import (
 	"github.com/GustyCube/membrane/pkg/membrane"
 )
 
+var version = "dev"
+
 func main() {
+	showVersion := flag.Bool("version", false, "print version and exit")
 	configPath := flag.String("config", "", "path to YAML config file")
 	dbPath := flag.String("db", "", "SQLite database path (overrides config)")
 	addr := flag.String("addr", "", "gRPC listen address (overrides config)")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println("membraned version", version)
+		os.Exit(0)
+	}
 
 	// Load configuration.
 	var cfg *membrane.Config


### PR DESCRIPTION
## Summary

Add a `--version` flag to the `membraned` CLI by introducing a package-level `version` variable (defaulting to `"dev"`) and checking for the `--version` argument before normal execution.

## Approach

In `cmd/membraned/main.go`: (1) Add a package-level variable `var version = "dev"` that can be overridden via `-ldflags "-X main.version=..."`. (2) At the beginning of `main()`, check if `os.Args` contains `--version` (or use the `flag` package to define a `--version` boolean flag). If set, print the version string (e.g., `fmt.Println("membraned version", version)`) and exit with code 0. This is fully compatible with the existing release workflow that injects version via ldflags, and local builds will show `dev` as the fallback.

## Files Changed

- `cmd/membraned/main.go`

## Related Issue

Fixes #31

## Testing

No tests were added with this change. Happy to add them if needed.
