### PR TITLE
Fix CI and deploy docs on Cloudflare Workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,12 @@ jobs:
           exit 1
 
       - name: Check formatting
-        run: test -z "$(gofmt -l .)"
+        run: |
+          UNFORMATTED="$(find . -name '*.go' -not -path './.git/*' -print0 | xargs -0 gofmt -l)"
+          if [ -n "$UNFORMATTED" ]; then
+            echo "$UNFORMATTED"
+            exit 1
+          fi
 
       - name: Check go mod tidy
         run: |

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,51 @@
+name: Cloudflare Docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - "src/**"
+      - "static/**"
+      - "docusaurus.config.js"
+      - "sidebars.js"
+      - "package.json"
+      - "package-lock.json"
+      - "wrangler.jsonc"
+      - ".github/workflows/docs-deploy.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build docs
+        run: npm run docs:build
+
+      - name: Deploy docs to Cloudflare Workers
+        if: env.CLOUDFLARE_API_TOKEN != ''
+        run: npx wrangler deploy
+
+      - name: Skip deploy without Cloudflare token
+        if: env.CLOUDFLARE_API_TOKEN == ''
+        run: |
+          echo "::notice::Set CLOUDFLARE_API_TOKEN as a repository secret to enable automatic docs deployment."

--- a/README.md
+++ b/README.md
@@ -278,7 +278,8 @@ are useful, instead of forcing tool calls in the harness.
 
 ## Documentation
 
-The docs site lives in [docs](docs) and is built with Docusaurus.
+The docs site lives in [docs](docs), is built with Docusaurus, and is deployed
+to Cloudflare Workers at <https://membrane.gustycube.com>.
 
 ```bash
 npm install
@@ -289,9 +290,12 @@ npm run docs:build
 npm run docs:deploy
 ```
 
-Cloudflare configuration is in [wrangler.jsonc](wrangler.jsonc). Sidebar and
-theme configuration live in [sidebars.js](sidebars.js) and
-[docusaurus.config.js](docusaurus.config.js).
+Cloudflare configuration is in [wrangler.jsonc](wrangler.jsonc). The GitHub
+Actions deploy workflow runs when docs files change and deploys when
+`CLOUDFLARE_API_TOKEN` is present as a repository secret. The
+`membrane.gustycube.com` DNS record must be proxied through Cloudflare for the
+Worker route to receive production traffic. Sidebar and theme configuration live
+in [sidebars.js](sidebars.js) and [docusaurus.config.js](docusaurus.config.js).
 
 ## API Surface
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,7 +3,7 @@
 const config = {
   title: "Membrane",
   tagline: "A selective learning and memory substrate for LLM and agentic systems.",
-  url: process.env.DOCS_SITE_URL ?? "https://membrane-docs.bennettschwartz32.workers.dev",
+  url: process.env.DOCS_SITE_URL ?? "https://membrane.gustycube.com",
   baseUrl: "/",
   organizationName: "BennettSchwartz",
   projectName: "membrane",

--- a/pkg/ingestion/capture_test.go
+++ b/pkg/ingestion/capture_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/BennettSchwartz/membrane/pkg/schema"
-	sqlitestore "github.com/BennettSchwartz/membrane/pkg/storage/sqlite"
 	"github.com/BennettSchwartz/membrane/pkg/storage"
+	sqlitestore "github.com/BennettSchwartz/membrane/pkg/storage/sqlite"
 )
 
 type stubInterpreter struct {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,6 +3,12 @@
   "name": "membrane-docs",
   "account_id": "776e99cad6263022ce616ccd9c25663e",
   "workers_dev": true,
+  "routes": [
+    {
+      "pattern": "membrane.gustycube.com/*",
+      "zone_name": "gustycube.com"
+    }
+  ],
   "compatibility_date": "2026-04-30",
   "assets": {
     "directory": "./build",


### PR DESCRIPTION
## Summary
- fix the Go formatting failure by formatting the offending test and making the CI formatter step print exact files
- add a Cloudflare Workers docs deployment workflow for the Docusaurus site
- point docs metadata and Wrangler routing at membrane.gustycube.com
- document the Cloudflare token and proxied DNS requirement in the README

## Verification
- make build
- make test
- npm --prefix clients/typescript run build
- npm --prefix examples/agent-harness run typecheck
- npm --prefix examples/agent-harness run test:deterministic
- npm run docs:build
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -color
- npx wrangler deploy --dry-run

## Deployment
- deployed Worker membrane-docs to Cloudflare successfully
- workers.dev URL serves the Docusaurus build
- membrane.gustycube.com still needs the existing Vercel DNS record proxied/replaced with DNS-edit credentials before the Worker route receives public traffic